### PR TITLE
components/app: allow multiple spaces between command arguments

### DIFF
--- a/components/app.js
+++ b/components/app.js
@@ -1302,7 +1302,7 @@ export default class App extends Component {
 	}
 
 	executeCommand(s) {
-		let parts = s.split(" ");
+		let parts = s.split(/ +/);
 		let name = parts[0].toLowerCase().slice(1);
 		let args = parts.slice(1);
 


### PR DESCRIPTION
Permits command arguments to have multiple spaces between them. In particular avoids erroring when one has typed `/j ` and then copy pastes the channel with a leading space.